### PR TITLE
Hide the troublesome icons (a redesign will eliminate them anyway).

### DIFF
--- a/src/components/Navigation/QuestionPage.vue
+++ b/src/components/Navigation/QuestionPage.vue
@@ -63,6 +63,7 @@
               :src="$vuetify.icons.values[item.image_icon].icon"
             />
           </div>
+          <!--
           <v-icon
             v-if="item.extra_icon"
             color="white"
@@ -86,6 +87,7 @@
           >
             {{ $vuetify.icons.values[item.icon].icon }}
           </v-icon>
+          -->
         </v-card>
       </v-col>
     </v-row>


### PR DESCRIPTION
This should work around the problem in #92. I'm guessing these icons will be eliminated anyway, whenever I'm able to get around to reworking the questions. 